### PR TITLE
ignore extra settings in the .env file

### DIFF
--- a/src/batchwizard/config.py
+++ b/src/batchwizard/config.py
@@ -12,7 +12,9 @@ class BatchWizardSettings(BaseSettings):
     api_key: Optional[str] = Field(None, env="OPENAI_API_KEY")
     max_concurrent_jobs: int = 5
     check_interval: int = 5
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
 
 class Config(BaseModel):


### PR DESCRIPTION
Using batchwizard in a project with unrelated settings in `.env` casues a crash, i.e.:


```
 File "/projects/foo/.venv/lib/python3.12/site-packages/batchwizard/config.py", line 19, in Config
    settings: BatchWizardSettings = BatchWizardSettings()
                                    ^^^^^^^^^^^^^^^^^^^^^
  File "/projects/foo/.venv/lib/python3.12/site-packages/pydantic_settings/main.py", line 176, in __init__
    super().__init__(
  File "/projects/foo/.venv/lib/python3.12/site-packages/pydantic/main.py", line 212, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 6 validation errors for BatchWizardSettings
my_setting
  Extra inputs are not permitted [type=extra_forbidden, input_value='foobar', input_type=str]
    For further information visit https://errors.pydantic.dev/2.9/v/extra_forbidden
```

This change fixes it by adding `extra="ignore"`. 

I think it would be better if the tool did not read `.env` unless explicitly asked to, but it seems like a larger change. 